### PR TITLE
Update Pixelogic PCB

### DIFF
--- a/pixelogic-pcb/README.md
+++ b/pixelogic-pcb/README.md
@@ -6,12 +6,17 @@ crossovers, and voltage sources are inferred from pixel shape.
 
 Live at <https://spencerschumann.github.io/pixelogic-pcb/>.
 
-## This is a published copy
+## This directory is generated — don't edit it here
 
 The source of truth is
 [`simulation/pixelogic_pcb`](https://github.com/spencerschumann/bitweaver_cpu/tree/main/simulation/pixelogic_pcb)
-in the `bitweaver_cpu` repository, where the app's design notes (`PLAN.md`)
-and tests live. Edit it there, then republish by copying these files across:
+in the `bitweaver_cpu` repository, where the app's design notes (`PLAN.md`) and
+tests live. Edit it there. A `Publish Pixelogic PCB` workflow in that
+repository copies the app into this directory and commits it automatically on
+every push to `main` that touches it, so anything changed here directly will be
+overwritten on the next sync.
+
+The synced files are:
 
     index.html  pixelogic-pcb.css  model.js  view.js  ui.js
     pwa.js  sw.js  manifest.webmanifest  icon-*.png
@@ -19,7 +24,3 @@ and tests live. Edit it there, then republish by copying these files across:
 Nothing else from that directory is needed — the app is static HTML/CSS/vanilla
 JS with no build step, and every path in it is relative, so it runs from this
 subdirectory as-is.
-
-When republishing, bump `CACHE_VERSION` in `sw.js` if you want installed copies
-to purge their old cached assets. The worker is network-first, so an online
-visit already picks up new code without it.

--- a/pixelogic-pcb/index.html
+++ b/pixelogic-pcb/index.html
@@ -28,13 +28,6 @@
             <div class="bar-group">
                 <button id="playPauseBtn" class="icon-btn" title="Play/Pause (P)" aria-pressed="false">&#x25B6;</button>
                 <button id="stepBtn" class="icon-btn" title="Step (Space)">&#x23ED;</button>
-                <span id="tickCount" class="tick-count">t=0</span>
-            </div>
-
-            <div class="bar-group speed-group">
-                <input id="intervalSlider" type="range" min="0" max="100" value="50" title="Simulation speed"
-                    aria-label="Simulation speed">
-                <span id="intervalValue" class="slider-value"></span>
             </div>
 
             <div class="bar-spacer"></div>
@@ -62,22 +55,22 @@
                 <div class="tool-group" aria-label="Materials">
                     <button class="tool-btn swatch-tool" data-tool="conductor" data-key="1"
                         title="Conductor (1) — right-drag always erases" style="--swatch:#3fae4a">Conductor</button>
-                    <button class="tool-btn swatch-tool" data-tool="gold" data-key="2" title="Mux control band (2)"
+                    <button class="tool-btn swatch-tool" data-tool="insulator" data-key="2"
+                        title="Erase / Insulator (2)" style="--swatch:#0d3b0d">Erase</button>
+                    <button class="tool-btn swatch-tool" data-tool="gold" data-key="3" title="Mux control band (3)"
                         style="--swatch:#e6b800">MUX Control</button>
-                    <button class="tool-btn swatch-tool" data-tool="gray" data-key="3" title="Mux body band (3)"
+                    <button class="tool-btn swatch-tool" data-tool="gray" data-key="4" title="Mux body band (4)"
                         style="--swatch:#2b2b2b">MUX Body</button>
-                    <button class="tool-btn swatch-tool" data-tool="pos" data-key="4" title="+V source (4)"
+                    <button class="tool-btn swatch-tool" data-tool="pos" data-key="5" title="+V source (5)"
                         style="--swatch:#ffffff">+V</button>
-                    <button class="tool-btn swatch-tool" data-tool="neg" data-key="5" title="&minus;V source (5)"
+                    <button class="tool-btn swatch-tool" data-tool="neg" data-key="6" title="&minus;V source (6)"
                         style="--swatch:#000000">&minus;V</button>
-                    <button class="tool-btn swatch-tool" data-tool="led" data-key="6" title="LED output (6)"
+                    <button class="tool-btn swatch-tool" data-tool="led" data-key="7" title="LED output (7)"
                         style="--swatch:#ff2a2a">LED</button>
-                    <button class="tool-btn swatch-tool" data-tool="switch" data-key="7"
-                        title="Momentary switch input (7)" style="--swatch:#9aa0a6">Switch</button>
-                    <button class="tool-btn swatch-tool" data-tool="toggle" data-key="T" title="Toggle switch input (T)"
+                    <button class="tool-btn swatch-tool" data-tool="toggle" data-key="8" title="Toggle switch input (8)"
                         style="--swatch:#565b60">Toggle</button>
-                    <button class="tool-btn swatch-tool" data-tool="insulator" data-key="8"
-                        title="Erase / Insulator (8)" style="--swatch:#0d3b0d">Erase</button>
+                    <button class="tool-btn swatch-tool" data-tool="switch" data-key="9"
+                        title="Momentary switch input (9)" style="--swatch:#9aa0a6">Switch</button>
                 </div>
 
                 <div class="tool-group" aria-label="Modes">
@@ -120,6 +113,12 @@
     <!-- ---- Overflow menu ---- -->
     <div id="menuBackdrop" class="modal-backdrop"></div>
     <div id="menuPanel" class="menu-panel" role="menu" aria-label="More">
+        <div class="menu-slider">
+            <label for="intervalSlider">Speed</label>
+            <input id="intervalSlider" type="range" min="0" max="1000" value="773" aria-label="Simulation speed">
+            <span id="intervalValue" class="menu-hint"></span>
+        </div>
+        <div class="menu-sep"></div>
         <button id="fitBtn" class="menu-item" role="menuitem">Fit to window<span class="menu-hint">F</span></button>
         <button id="gridToggleBtn" class="menu-item" role="menuitem" aria-pressed="true"
             title="Remembered separately for build vs. Interact">Grid lines<span class="menu-hint">G</span></button>

--- a/pixelogic-pcb/pixelogic-pcb.css
+++ b/pixelogic-pcb/pixelogic-pcb.css
@@ -102,32 +102,23 @@ html, body {
     display: flex;
     align-items: center;
     gap: 4px;
-    /* The bar stays a single row at every width. Groups hold their size and
-       never wrap; the speed slider is the one thing allowed to give, and
-       below 420px the whole zoom group steps aside (see that breakpoint) —
-       so the controls that go first are chosen rather than whichever
-       happened to be last. */
+    /* The bar stays a single row at every width, and holds only controls
+       that earn a permanent place: run, undo/redo, zoom, menu. Groups never
+       wrap or shrink — anything that would not fit is moved into the menu
+       instead. */
     flex: 0 0 auto;
 }
 
 .bar-spacer { flex: 1 1 auto; min-width: 0; }
 
-.speed-group { flex: 0 1 auto; min-width: 0; }
-#intervalSlider {
-    width: 110px;
-    min-width: 48px;
-    flex: 0 1 auto;
-    accent-color: var(--pcb-conductor);
+/* Pinch-zoom is the gesture people already reach for on a touchscreen, so
+   the zoom buttons only appear where there is a precise pointer and no
+   pinch. (Fit lives in the menu, reachable either way.) */
+@media (pointer: coarse) {
+    .zoom-group { display: none; }
 }
 
-.tick-count {
-    font-family: ui-monospace, monospace;
-    font-size: 12px;
-    color: var(--text-dim);
-    min-width: 3.5em;
-}
-
-.slider-value, .zoom-value {
+.zoom-value {
     font-family: ui-monospace, monospace;
     font-size: 12px;
     color: var(--text-dim);
@@ -290,20 +281,14 @@ html, body {
     .tool-btn[data-key]::after { display: none; }
 }
 
-/* Very narrow phones. Play, speed, undo/redo and the menu are what has to
-   survive, so the tick readout and the whole zoom cluster give up their
-   space — pinch-zoom is the natural gesture here anyway, and Fit lives in
-   the menu. The tool chips shrink so more than four are reachable without
-   scrolling. */
+/* Very narrow phones: shrink the tool chips so more than four are reachable
+   without scrolling. */
 @media (max-width: 420px) {
     #topbar {
         gap: 5px;
         padding-left: max(6px, env(safe-area-inset-left));
         padding-right: max(6px, env(safe-area-inset-right));
     }
-    .tick-count, .zoom-group { display: none; }
-    .slider-value { min-width: 3.5em; }
-    #intervalSlider { width: 64px; }
     .tool-btn[data-tool] { min-width: 50px; font-size: 9px; }
 }
 
@@ -430,6 +415,26 @@ html, body {
     font-size: 11px;
     color: #6d6d6d;
     font-family: ui-monospace, monospace;
+}
+
+/* Speed lives in the menu rather than the top bar — it is set once in a
+   while, not per action, and inline it cost the bar more room than anything
+   else on it. Not a .menu-item, so dragging it doesn't dismiss the menu. */
+.menu-slider {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: var(--hit);
+    padding: 0 10px;
+    font-size: 13px;
+}
+.menu-slider label { color: var(--text); }
+.menu-slider .menu-hint { min-width: 4.5em; text-align: right; }
+
+#intervalSlider {
+    flex: 1 1 auto;
+    min-width: 80px;
+    accent-color: var(--pcb-conductor);
 }
 
 .menu-sep {

--- a/pixelogic-pcb/ui.js
+++ b/pixelogic-pcb/ui.js
@@ -34,13 +34,15 @@
     let running = false;
     // Exponential so the slider gives fine control at the slow end and still
     // reaches a genuinely fast rate at the top (was capped at 20 steps/s).
-    const MIN_TPS = 1, MAX_TPS = 200;
-    let tickIntervalMs = 1000 / MIN_TPS;
+    // The default is fast enough that a circuit visibly *runs* on first
+    // contact rather than creeping; the slider is there to slow it down when
+    // you want to watch a signal propagate.
+    const MIN_TPS = 1, MAX_TPS = 200, DEFAULT_TPS = 60;
+    let tickIntervalMs = 1000 / DEFAULT_TPS;
     let lastTick = 0;
     let panning = false;
     let lastPanPos = null;
 
-    const tickCountEl = document.getElementById('tickCount');
     const playPauseBtn = document.getElementById('playPauseBtn');
     const zoomValueEl = document.getElementById('zoomValue');
     const intervalSlider = document.getElementById('intervalSlider');
@@ -160,11 +162,21 @@
     const UNDO_LIMIT = 100;
     let undoBatchOpen = false;
 
-    // Each entry snapshots the circuit AND the pan, so undoing an edit that
-    // auto-grew the grid restores both the smaller grid and the matching pan —
-    // the drawing lands back exactly where it was.
+    // How many columns/rows the grid has grown off its left and top edges
+    // since the app started. Cell coordinates shift by this whenever
+    // expandForBorder() adds space, so it's what lets an undo tell "the grid
+    // moved under the drawing" apart from "the user panned".
+    const gridOrigin = { x: 0, y: 0 };
+
+    // Each entry snapshots the circuit and that origin — NOT the pan or zoom.
+    // Undo used to restore the pan outright, which meant any panning or
+    // zooming you did after an edit was thrown away the moment you undid it:
+    // the view jumped, which is jarring and never what undo was asked to do.
+    // Recording the origin instead is enough to keep the drawing visually
+    // still across an undo that shrinks the grid, while leaving the view
+    // exactly where you put it.
     function snapshotEntry() {
-        return { snap: M.getStructuralSnapshot(), panX: V.panX, panY: V.panY, zoom: V.zoom };
+        return { snap: M.getStructuralSnapshot(), originX: gridOrigin.x, originY: gridOrigin.y };
     }
     function beginUndoBatch() {
         if (undoBatchOpen) return;
@@ -178,9 +190,15 @@
 
     function restoreEntry(e) {
         M.restoreStructuralSnapshot(e.snap);
-        V.setZoom(e.zoom);
-        V.setPan(e.panX, e.panY);
-        updateZoomLabel();
+        // Restoring a differently-sized grid re-lays the cells at the
+        // snapshot's coordinates, so shift the pan by exactly the difference
+        // in origin — the drawing stays put on screen and the zoom, and any
+        // panning done since, are left alone.
+        const cs = M.CELL_SIZE * V.zoom;
+        const dx = (gridOrigin.x - e.originX) * cs, dy = (gridOrigin.y - e.originY) * cs;
+        if (dx || dy) V.pan(dx, dy);
+        gridOrigin.x = e.originX;
+        gridOrigin.y = e.originY;
     }
     function undo() {
         if (!undoStack.length) return;
@@ -633,7 +651,11 @@
     // {left, top, right, bottom} added.
     function applyExpansion() {
         const g = M.expandForBorder();
-        if (g.left || g.top) V.compensateExpansion(g.left, g.top);
+        if (g.left || g.top) {
+            V.compensateExpansion(g.left, g.top);
+            gridOrigin.x += g.left;
+            gridOrigin.y += g.top;
+        }
         return g;
     }
 
@@ -1014,7 +1036,6 @@
         playPauseBtn.addEventListener('click', () => setRunning(!running));
         document.getElementById('stepBtn').addEventListener('click', () => {
             M.stepSimulation();
-            tickCountEl.textContent = `t=${M.tickCount}`;
             V.drawGrid();
         });
         document.getElementById('clearBtn').addEventListener('click', () => {
@@ -1023,12 +1044,10 @@
             M.clearGrid();
             endUndoBatch();
             setSelection(null);
-            tickCountEl.textContent = `t=${M.tickCount}`;
             afterEdit();
         });
         document.getElementById('resetChargesBtn').addEventListener('click', () => {
             M.resetCharges();
-            tickCountEl.textContent = `t=${M.tickCount}`;
             V.drawGrid();
             scheduleSave();
         });
@@ -1047,6 +1066,7 @@
         componentsCloseBtn.addEventListener('click', closeComponents);
         componentsBackdrop.addEventListener('click', closeComponents);
 
+        intervalSlider.value = String(sliderPosForTps(DEFAULT_TPS));
         intervalSlider.addEventListener('input', updateIntervalFromSlider);
         updateIntervalFromSlider();
 
@@ -1078,7 +1098,10 @@
             const ok = M.deserialize(text);
             endUndoBatch();
             if (ok) {
-                tickCountEl.textContent = `t=${M.tickCount}`;
+                // An imported grid brings its own coordinate frame, and the
+                // view is refit to it, so the origin starts over from here.
+                gridOrigin.x = 0;
+                gridOrigin.y = 0;
                 V.fitToWindow(); updateZoomLabel();
                 afterEdit();
                 flashStatus('Imported');
@@ -1099,11 +1122,19 @@
         statusTimer = setTimeout(() => { statusEl.textContent = ''; }, 1500);
     }
 
+    // The slider's own max is the resolution: it's fine-grained (1000 steps)
+    // so that a whole-number target rate like DEFAULT_TPS lands on it exactly
+    // instead of a step either side of it.
     function updateIntervalFromSlider() {
         const v = Number(intervalSlider.value);
-        const tps = MIN_TPS * Math.pow(MAX_TPS / MIN_TPS, v / 100);
+        const tps = MIN_TPS * Math.pow(MAX_TPS / MIN_TPS, v / Number(intervalSlider.max));
         tickIntervalMs = 1000 / tps;
         intervalValueEl.textContent = `${Math.round(tps)} tps`;
+    }
+    // The scale is exponential, so the position for a given rate is derived
+    // rather than hard-coded — changing DEFAULT_TPS is enough.
+    function sliderPosForTps(tps) {
+        return Math.round(Number(intervalSlider.max) * Math.log(tps / MIN_TPS) / Math.log(MAX_TPS / MIN_TPS));
     }
 
     // A tick interval faster than one frame (~16ms at 60Hz) can't be reached by
@@ -1121,10 +1152,7 @@
                 steps++;
             }
             if (now - lastTick >= tickIntervalMs) lastTick = now; // drop any remaining backlog
-            if (steps > 0) {
-                tickCountEl.textContent = `t=${M.tickCount}`;
-                V.drawGrid();
-            }
+            if (steps > 0) V.drawGrid();
         } else {
             lastTick = now;
         }
@@ -1177,15 +1205,18 @@
 
         if (e.key === ' ') { e.preventDefault(); document.getElementById('stepBtn').click(); }
         else if (e.key === 'p' || e.key === 'P') setRunning(!running);
+        // Digits follow the rail's order top-to-bottom. Erase sits second,
+        // next to Conductor, because reaching for it is as constant as
+        // reaching for wire.
         else if (e.key === '1') setDrawMode('conductor');
-        else if (e.key === '2') setDrawMode('gold');
-        else if (e.key === '3') setDrawMode('gray');
-        else if (e.key === '4') setDrawMode('pos');
-        else if (e.key === '5') setDrawMode('neg');
-        else if (e.key === '6') setDrawMode('led');
-        else if (e.key === '7') setDrawMode('switch');
-        else if (e.key === '8') setDrawMode('insulator');
-        else if (e.key === 't' || e.key === 'T') setDrawMode('toggle');
+        else if (e.key === '2') setDrawMode('insulator');
+        else if (e.key === '3') setDrawMode('gold');
+        else if (e.key === '4') setDrawMode('gray');
+        else if (e.key === '5') setDrawMode('pos');
+        else if (e.key === '6') setDrawMode('neg');
+        else if (e.key === '7') setDrawMode('led');
+        else if (e.key === '8') setDrawMode('toggle');
+        else if (e.key === '9') setDrawMode('switch');
         else if (e.key === 'i' || e.key === 'I') setDrawMode('interact');
         else if (e.key === 's' || e.key === 'S') setDrawMode('select');
         else if (e.key === 'a' || e.key === 'A') setDrawMode('rearrange');
@@ -1208,7 +1239,6 @@
         updateZoomLabel();
         updateActionButtons();
         V.drawGrid();
-        tickCountEl.textContent = `t=${M.tickCount}`;
         requestAnimationFrame(tickLoop);
     }
 


### PR DESCRIPTION
Undo/redo no longer move the view; speed moved into the overflow menu and now defaults to 60 ticks/s; the tick counter is gone; zoom buttons hide on touch devices; and Erase moved up beside Conductor with the material shortcuts renumbered to follow the rail.

This directory is now kept in sync automatically by a workflow in the bitweaver_cpu repository, so it should not be edited here — README.md says so and no longer describes the manual copy.


Claude-Session: https://claude.ai/code/session_018Es4m35GFR6VfXSADBfR1F